### PR TITLE
Can split terminals in the terminal pane

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -684,6 +684,7 @@
       "ctrl-alt-space": "terminal::ShowCharacterPalette",
       "ctrl-insert": "terminal::Copy",
       "shift-insert": "terminal::Paste",
+      "ctrl-\\": "workspace::SplitTerminal",
       "ctrl-enter": "assistant::InlineAssist",
       // Overrides for conflicting keybindings
       "ctrl-w": ["terminal::SendKeystroke", "ctrl-w"],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -684,6 +684,7 @@
       "cmd-v": "terminal::Paste",
       "cmd-a": "editor::SelectAll",
       "cmd-k": "terminal::Clear",
+      "cmd-\\": "workspace::SplitTerminal",
       "ctrl-enter": "assistant::InlineAssist",
       // Some nice conveniences
       "cmd-backspace": ["terminal::SendText", "\u0015"],

--- a/crates/terminal_view/src/terminal_group.rs
+++ b/crates/terminal_view/src/terminal_group.rs
@@ -1,0 +1,43 @@
+/// A group of terminals that can be arranged horizontally or vertically.
+/// A pane may have multiple terminal groups, each created on `workspace::NewTerminal`.
+/// TODO(dennis): I am adopting VSCode's TerminalGroup idea.
+pub struct TerminalGroup {
+    terminals: Vec<View<TerminalView>>,
+    split_direction: SplitDirection,
+    active_terminal_index: usize,
+}
+
+/// TODO(dennis): Can we replace this with an existing enum from the pane model?
+pub enum SplitDirection {
+    Horizontal,
+    Vertical,
+}
+
+impl TerminalGroup {
+    pub fn new() -> Self {
+        Self {
+            terminals: Vec::new(),
+            split_direction: SplitDirection::Horizontal,
+            active_terminal_index: 0,
+        }
+    }
+
+    pub fn split_terminal(&mut self, cx: &mut ViewContext<Self>) {
+        let terminal = self.terminals[self.active_terminal_index].clone();
+        let terminal_view = terminal.read(cx);
+        let new_terminal = terminal_view.split_terminal(cx);
+        self.terminals.push(new_terminal);
+    }
+
+    pub fn set_split_direction(&mut self, split_direction: SplitDirection) {
+        self.split_direction = split_direction;
+    }
+
+    pub fn set_active_terminal(&mut self, index: usize) {
+        self.active_terminal_index = index;
+    }
+
+    pub fn close_terminal(&mut self, cx: &mut ViewContext<Self>, index: usize) {
+        self.terminals.remove(index);
+    }
+}

--- a/crates/terminal_view/src/terminal_group.rs
+++ b/crates/terminal_view/src/terminal_group.rs
@@ -14,9 +14,9 @@ pub enum SplitDirection {
 }
 
 impl TerminalGroup {
-    pub fn new() -> Self {
+    pub fn new(initial_terminal: Terminal) -> Self {
         Self {
-            terminals: Vec::new(),
+            terminals: vec![initial_terminal],
             split_direction: SplitDirection::Horizontal,
             active_terminal_index: 0,
         }
@@ -39,5 +39,22 @@ impl TerminalGroup {
 
     pub fn close_terminal(&mut self, cx: &mut ViewContext<Self>, index: usize) {
         self.terminals.remove(index);
+    }
+}
+
+impl Render for TerminalGroup {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        match self.split_direction {
+            SplitDirection::Horizontal => h_flex().size_full().children(
+                self.terminals
+                    .iter()
+                    .map(|terminal| div().size_full().flex_1().child(terminal.clone())),
+            ),
+            SplitDirection::Vertical => v_flex().size_full().children(
+                self.terminals
+                    .iter()
+                    .map(|terminal| div().size_full().flex_1().child(terminal.clone())),
+            ),
+        }
     }
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -627,6 +627,9 @@ impl TerminalPanel {
                 let terminal = workspace
                     .project()
                     .update(cx, |project, cx| project.create_terminal(kind, window, cx))?;
+
+                // TODO(dennis): Unsure how we handle "models" and "views".
+                // I think I want the TerminalView to hold a Model<TerminalGroup> seeing as how it currently holds a Model<Terminal>.
                 let terminal_view = Box::new(cx.new_view(|cx| {
                     TerminalView::new(
                         terminal.clone(),

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -44,6 +44,7 @@ pub fn init(cx: &mut AppContext) {
         |workspace: &mut Workspace, _: &mut ViewContext<Workspace>| {
             workspace.register_action(TerminalPanel::new_terminal);
             workspace.register_action(TerminalPanel::open_terminal);
+            workspace.register_action(TerminalPanel::split_terminal);
             workspace.register_action(|workspace, _: &ToggleFocus, cx| {
                 if workspace
                     .panel::<TerminalPanel>(cx)
@@ -84,7 +85,7 @@ impl TerminalPanel {
                 NewTerminal.boxed_clone(),
                 cx,
             );
-            pane.set_can_split(false, cx);
+            pane.set_can_split(true, cx);
             pane.set_can_navigate(false, cx);
             pane.display_nav_history_buttons(None);
             pane.set_should_display_tab_bar(|_| true);
@@ -552,6 +553,41 @@ impl TerminalPanel {
                 this.add_terminal(kind, RevealStrategy::Always, cx)
             })
             .detach_and_log_err(cx);
+    }
+
+    fn split_terminal(
+        workspace: &mut Workspace,
+        _: &workspace::SplitTerminal,
+        cx: &mut ViewContext<Workspace>,
+    ) {
+        let Some(terminal_panel) = workspace.panel::<Self>(cx) else {
+            return;
+        };
+
+        let kind = TerminalKind::Shell(default_working_directory(workspace, cx));
+
+        terminal_panel
+            .update(cx, |this, cx| {
+                println!("Splitting terminal");
+                this.add_terminal(kind, RevealStrategy::Always, cx)
+            })
+            .detach_and_log_err(cx);
+
+        // terminal_panel.update(cx, |this, cx| {
+        //     // Split the terminal
+        //     if let Some(active_terminal) = this.pane.read(cx).active_item() {
+        //         println!("Splitting terminal");
+        //         println!("Active terminal: {:?}", active_terminal);
+        //         // TODO: Implement split terminal functionality
+        //         // this.pane.update(cx, |pane, cx| {
+        //         //     pane.split_item(active_terminal, gpui::Split::Right, cx);
+        //         // });
+        //     }
+
+        //     // Create new terminal in the split
+        //     // this.add_terminal(kind, RevealStrategy::Always, cx)
+        // })
+        // .detach_and_log_err(cx);
     }
 
     fn terminals_for_task(

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -74,6 +74,15 @@ pub struct TerminalPanel {
     assistant_tab_bar_button: Option<AnyView>,
 }
 
+/// A group of terminals that can be arranged horizontally or vertically.
+/// A pane may have multiple terminal groups, each created on `workspace::NewTerminal`.
+/// TODO(dennis): I am adopting VSCode's TerminalGroup idea.
+pub struct TerminalGroup {
+    instances: Vec<TerminalView>,
+    // VSCode has an orientation feature, but to be quick here, we'll only support horizontal for now.
+    // orientation: Orientation,
+}
+
 impl TerminalPanel {
     fn new(workspace: &Workspace, cx: &mut ViewContext<Self>) -> Self {
         let pane = cx.new_view(|cx| {
@@ -569,6 +578,7 @@ impl TerminalPanel {
         terminal_panel
             .update(cx, |this, cx| {
                 println!("Splitting terminal");
+
                 this.add_terminal(kind, RevealStrategy::Always, cx)
             })
             .detach_and_log_err(cx);
@@ -617,6 +627,7 @@ impl TerminalPanel {
         })
     }
 
+    /// TODO(dennis): Adding a new terminal should instead add a new TerminalGroup.
     fn add_terminal(
         &mut self,
         kind: TerminalKind,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -33,8 +33,8 @@ use workspace::{
     notifications::NotifyResultExt,
     register_serializable_item,
     searchable::{SearchEvent, SearchOptions, SearchableItem, SearchableItemHandle},
-    CloseActiveItem, NewCenterTerminal, NewTerminal, OpenVisible, Pane, ToolbarItemLocation,
-    Workspace, WorkspaceId,
+    CloseActiveItem, NewCenterTerminal, NewTerminal, OpenVisible, Pane, SplitTerminal,
+    ToolbarItemLocation, Workspace, WorkspaceId,
 };
 
 use anyhow::Context;
@@ -229,6 +229,7 @@ impl TerminalView {
         let context_menu = ContextMenu::build(cx, |menu, _| {
             menu.context(self.focus_handle.clone())
                 .action("New Terminal", Box::new(NewTerminal))
+                .action("Split Terminal", Box::new(SplitTerminal))
                 .separator()
                 .action("Copy", Box::new(Copy))
                 .action("Paste", Box::new(Paste))

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -147,6 +147,7 @@ actions!(
         NewFileSplitHorizontal,
         NewSearch,
         NewTerminal,
+        SplitTerminal,
         NewWindow,
         Open,
         OpenInTerminal,


### PR DESCRIPTION
My attempt at https://github.com/zed-industries/zed/issues/4351 because I really want this feature.

## Plan

Inspired by VSCode's implementation of TerminalGroup, we'll copy this concept over to Zed. When you create terminals today in the dock (the primary "terminal pane"), a new instance of TerminalView is instantiated. Each TerminalView then holds a Terminal. Instead of a single Terminal per TerminalView, we'll swap it with a TerminalGroup model where in each group is a list of Terminals.

* [x] Introduce TerminalGroup
* [ ] Replace relationship of TerminalView and Terminal with TerminalView + TerminalGroup
* [ ] TBD

## Discussion Questions

1. Should we think about a unified pane abstraction now? I don't have enough knowledge to think beyond the feature, so I'll continue with the current terminal abstractions, only introducing a new TerminalGroup.
2. Similar to 1, we can move terminals into different panes. How can we ensure we also move TerminalGroups? Is that already handled by the TerminalView?

## Release Notes

Adds a new action `workspace::SplitTerminal` with a default keymap `cmd-\\` (macOS) to create a new terminal view to the right of the active terminal. 

