### PR TITLE
Notify users via toast instead of silently logging generic lsp response errors

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1366,6 +1366,7 @@ impl LspStore {
                 let lsp_request = language_server.request::<R::LspRequest>(lsp_params);
 
                 let id = lsp_request.id();
+
                 let _cleanup = if status.is_some() {
                     cx.update(|cx| {
                         this.update(cx, |this, cx| {
@@ -1405,11 +1406,13 @@ impl LspStore {
                 let result = lsp_request.await;
 
                 let response = result.map_err(|err| {
-                    log::warn!(
-                        "Generic lsp request to {} failed: {}",
-                        language_server.name(),
-                        err
-                    );
+                    cx.update(|cx| {
+                        this.update(cx, |_, cx| {
+                            cx.emit(LspStoreEvent::Notification(err.to_string()));
+                        })
+                    })
+                    .log_err();
+
                     err
                 })?;
 
@@ -6531,6 +6534,7 @@ impl LspStore {
                 }
             })
             .detach();
+
         language_server
             .on_notification::<lsp::notification::ShowMessage, _>({
                 let this = this.clone();


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21695

Release Notes:

- Zed will report generic LSP errors to the users instead of silently logging.
